### PR TITLE
Update makepkg.conf

### DIFF
--- a/pacman-git/makepkg.conf
+++ b/pacman-git/makepkg.conf
@@ -47,7 +47,7 @@ LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
          -Wl,-z,pack-relative-relocs"
 
 LTOFLAGS="-flto=auto"
-RUSTFLAGS="-C opt-level=3 -C target-cpu=native"
+RUSTFLAGS="-C target-cpu=native"
 #-- Make Flags: change this for DistCC/SMP systems
 MAKEFLAGS="-j$(nproc)"
 NINJAFLAGS="-j$(nproc)"


### PR DESCRIPTION
Removed "-C opt-level=3" from RUSTFLAGS since the Rust default release profile uses opt-level=3 and because the Arch Linux packaging guidelines specify using the release profile when building Rust packages.